### PR TITLE
Update API endpoint

### DIFF
--- a/pointdns.php
+++ b/pointdns.php
@@ -152,7 +152,7 @@ class PointDNS {
     $process = curl_init();
 
     curl_setopt($process, CURLOPT_CUSTOMREQUEST, $method);
-    curl_setopt($process, CURLOPT_URL, 'https://pointhq.com' . $path);
+    curl_setopt($process, CURLOPT_URL, 'https://api.pointhq.com' . $path);
     curl_setopt($process, CURLOPT_USERPWD, $this->username . ":" . $this->apitoken);
     curl_setopt($process, CURLOPT_TIMEOUT, $this->timeout);
 


### PR DESCRIPTION
The URL of the API endpoint has changed from https://pointhq.com to https://api.pointhq.com. This PR updates the code to match.
